### PR TITLE
Fix do not include second-generation package ancestors in the scratch org

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ There are examples that uses following APIs:
 1. Create a scratch org to setup integration examples.
 
 ```sh
-$ sfdx force:org:create -f config/project-scratch-def.json -a msmx-sheet-integration -w 10
+$ sfdx force:org:create -f config/project-scratch-def.json -a msmx-sheet-integration -c -w 10
 ```
 
 2. Install Mashmatrix Sheet trial package from command line.

--- a/README_ja.md
+++ b/README_ja.md
@@ -20,7 +20,7 @@
 1. インテグレーションサンプルをセットアップするスクラッチ組織を作成します
 
 ```sh
-$ sfdx force:org:create -f config/project-scratch-def.json -a msmx-sheet-integration -w 10
+$ sfdx force:org:create -f config/project-scratch-def.json -a msmx-sheet-integration -c -w 10
 ```
 
 2. コマンドラインでMashmatrix Sheetのトライアルパッケージをインストールします


### PR DESCRIPTION
## What I Did:
- add option -c to Do not include second-generation package ancestors in the scratch org