### PR TITLE
Feature sheet playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ Similarly, it will set the `parameters` property for the 3rd sheet to the value 
 
 ### Sheet Playground (Custom Code Integration)
 
+<img width="1920" height="1688" alt="sheet-playground" src="https://github.com/user-attachments/assets/3eb61ff9-e230-4ed7-a8d5-6088f7112cce" />
+
 This sample demonstrates how to embed and control the **Mashmatrix Sheet LWC component (`<msmx-sheet-sheet>`)** directly within a custom Lightning Web Component's template. 
 
 Unlike Dynamic Interaction which relies on App Builder configuration, this approach uses standard LWC property binding and event handling.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ $ sf org open -o msmx-sheet-integration -p /lightning/n/msmxSheet__MashmatrixShe
 
 20. Select "Mashmatrix Sheet" component in left pane, replace "Book ID" value to the copied book Id of "Custom Event" book in step 9.
 
+21. Open "Sheet Playground" tab. This sample is already wired as a self-contained custom component, so you can use it directly without arranging the page in App Builder.
+
 ## Examples
 
 ### Map Integration
@@ -141,3 +143,26 @@ The "Account Chart" component will display the total amount from Opportunities g
 When clicking on a bar in the chart, it will publish a dynamic interaction event that includes the properties (accountId, startDate, endDate, year).
 The dynamic interaction event will set the `parameters` property of the 2nd sheet to the value `accountId={!Event.accountId}&startDate={!Event.startDate}&endDate={!Event.endDate}`, since the filter is set to the closeDate and accountId columns, the 2nd sheet will refresh according to the selected accountId and startDate, endDate
 Similarly, it will set the `parameters` property for the 3rd sheet to the value `year={!Event.year}`, since the filter of the 3rd sheet is set to the year column, the 3rd sheet will be refreshed according to the selected year
+
+### Sheet Playground (Custom Code Integration)
+
+This sample demonstrates how to embed and control the **Mashmatrix Sheet LWC component (`<msmx-sheet-sheet>`)** directly within a custom Lightning Web Component's template. 
+
+Unlike Dynamic Interaction which relies on App Builder configuration, this approach uses standard LWC property binding and event handling.
+
+The left panel (Control Surface) lets you:
+- switch the active book and sheet
+- edit draft settings for the component
+- apply staged settings with a dedicated action button
+- toggle `publish-events`
+- set the sheet height as a CSS value such as `500px` or `80vh`
+- change the context record ID
+- use the currently selected record as the context record
+
+**Technical highlights in this sample:**
+- **Component Embedding:** Usage of `<msmx-sheet-sheet>` in HTML.
+- **Property Binding:** Dynamically passing `book-id`, `sheet-id`, `parameters`, and `context-record-id` from JavaScript.
+- **Event Handling:** Capturing the `selectrecord` event to retrieve selected record IDs directly in the parent component.
+- **Manual Application:** Using a "Draft vs Applied" state pattern to control when the Sheet component should refresh.
+
+When the page loads, the component automatically selects the first available book. The sheet is left unselected until you choose one, because some books may not need a default sheet.

--- a/README_ja.md
+++ b/README_ja.md
@@ -145,6 +145,8 @@ $ sf org open -o msmx-sheet-integration -p /lightning/n/msmxSheet__MashmatrixShe
 
 ### Sheet Playground (カスタムコード統合)
 
+<img width="1920" height="1688" alt="sheet-playground" src="https://github.com/user-attachments/assets/59834dda-4fe7-461a-8dde-7f35f843f39b" />
+
 このサンプルは、カスタム Lightning Web コンポーネントのテンプレート内で **Mashmatrix Sheet LWC コンポーネント (`<msmx-sheet-sheet>`)** を直接埋め込み、制御する方法を示しています。
 
 App Builder の Dynamic Interaction（動的インタラクション）に依存せず、標準の LWC プロパティバインディングとイベントハンドリングを使用して統合を行う手法を解説します。

--- a/README_ja.md
+++ b/README_ja.md
@@ -142,3 +142,26 @@ $ sf org open -o msmx-sheet-integration -p /lightning/n/msmxSheet__MashmatrixShe
 この Dynamic Interaction イベントは、第 2 のシートの parameters プロパティに accountId={!Event.accountId}&startDate={!Event.startDate}&endDate={!Event.endDate} という値を設定します。
 第 2 のシートでは、フィルターが closeDate と accountId 列に設定されているため、選択された accountId および startDate、endDate に基づいて自動的に更新されます。
 同様に、第 3 のシートには year={!Event.year} の値で parameters プロパティが設定されており、こちらも year 列にフィルターが設定されているため、選択された year に応じて更新されます。
+
+### Sheet Playground (カスタムコード統合)
+
+このサンプルは、カスタム Lightning Web コンポーネントのテンプレート内で **Mashmatrix Sheet LWC コンポーネント (`<msmx-sheet-sheet>`)** を直接埋め込み、制御する方法を示しています。
+
+App Builder の Dynamic Interaction（動的インタラクション）に依存せず、標準の LWC プロパティバインディングとイベントハンドリングを使用して統合を行う手法を解説します。
+
+左ペイン（コントロールパネル）でできること:
+- book / sheet を切り替える
+- コンポーネントの draft 設定を編集する
+- `Apply Settings` ボタンで変更内容を反映する
+- `publish-events` を切り替える
+- sheet の高さを `500px` や `80vh` のような CSS 値で指定する
+- context record ID を変更する
+- 選択中のレコードを context record に反映する
+
+**技術的なポイント:**
+- **コンポーネントの埋め込み:** HTML での `<msmx-sheet-sheet>` の使用。
+- **プロパティバインディング:** `book-id`、`sheet-id`、`parameters`、`context-record-id` を JavaScript から動的に渡す方法。
+- **イベントハンドリング:** `selectrecord` イベントをキャプチャして、選択されたレコード ID を親コンポーネントで直接取得する方法。
+- **設定の反映制御:** 「Draft（下書き）」と「Applied（適用済み）」の状態を使い分け、任意のタイミングでシートを更新するパターン。
+
+ページ表示時には、取得できる最初の book が自動選択されます。sheet は null のまま開始できるようにしているため、自動では選択しません。

--- a/force-app/main/default/applications/Mashmatrix_Sheet_Integration_Examples.app-meta.xml
+++ b/force-app/main/default/applications/Mashmatrix_Sheet_Integration_Examples.app-meta.xml
@@ -16,5 +16,6 @@
     <tabs>Message_Debug</tabs>
     <tabs>Custom_Event</tabs>
     <tabs>Dynamic_Interaction</tabs>
+    <tabs>Sheet_Playground</tabs>
     <uiType>Lightning</uiType>
 </CustomApplication>

--- a/force-app/main/default/classes/SheetPlaygroundController.cls
+++ b/force-app/main/default/classes/SheetPlaygroundController.cls
@@ -1,0 +1,19 @@
+public with sharing class SheetPlaygroundController {
+    @AuraEnabled(cacheable=true)
+    public static List<msmxSheet__msmxBook__c> getBooks() {
+        return [SELECT Id, Name FROM msmxSheet__msmxBook__c ORDER BY Name];
+    }
+
+    @AuraEnabled(cacheable=true)
+    public static List<msmxSheet__msmxSheet__c> getSheets(Id bookId) {
+        if (bookId == null) {
+            return new List<msmxSheet__msmxSheet__c>();
+        }
+        return [
+            SELECT Id, Name, msmxSheet__SheetId__c
+            FROM msmxSheet__msmxSheet__c
+            WHERE msmxSheet__Book__c = :bookId
+            ORDER BY Name
+        ];
+    }
+}

--- a/force-app/main/default/classes/SheetPlaygroundController.cls-meta.xml
+++ b/force-app/main/default/classes/SheetPlaygroundController.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/flexipages/Sheet_Playground.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/Sheet_Playground.flexipage-meta.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FlexiPage xmlns="http://soap.sforce.com/2006/04/metadata">
+    <flexiPageRegions>
+        <itemInstances>
+            <componentInstance>
+                <componentName>sheetPlayground</componentName>
+                <identifier>c_sheetPlayground</identifier>
+            </componentInstance>
+        </itemInstances>
+        <name>main</name>
+        <type>Region</type>
+    </flexiPageRegions>
+    <masterLabel>Sheet Playground</masterLabel>
+    <template>
+        <name>flexipage:defaultAppHomeTemplate</name>
+    </template>
+    <type>AppPage</type>
+</FlexiPage>

--- a/force-app/main/default/lwc/sheetIntegrationExample/sheetIntegrationExample.css
+++ b/force-app/main/default/lwc/sheetIntegrationExample/sheetIntegrationExample.css
@@ -1,0 +1,41 @@
+:host {
+  display: block;
+}
+
+.sheet-container {
+  min-height: 560px;
+}
+
+.event-log {
+  min-height: 180px;
+  max-height: 180px;
+  overflow-y: auto;
+  padding: 0.75rem;
+}
+
+.event-log > div {
+  border-bottom: 1px solid #dddbda;
+}
+
+.event-log > div:last-child {
+  border-bottom: none;
+}
+
+lightning-card {
+  display: block;
+}
+
+.slds-col lightning-card:not(:first-child) {
+  margin-top: 1rem;
+}
+
+@media screen and (max-width: 1024px) {
+  .sheet-container {
+    min-height: 480px;
+  }
+
+  .event-log {
+    min-height: 150px;
+    max-height: 150px;
+  }
+}

--- a/force-app/main/default/lwc/sheetIntegrationExample/sheetIntegrationExample.html
+++ b/force-app/main/default/lwc/sheetIntegrationExample/sheetIntegrationExample.html
@@ -1,0 +1,144 @@
+<template>
+  <lightning-card title="Sheet Integration Example">
+    <div class="slds-p-around_medium">
+      <div class="slds-grid slds-gutters">
+        <!-- Left Panel -->
+        <div class="slds-col slds-size_1-of-4">
+          <!-- Record Context -->
+          <lightning-card title="Record Context">
+            <div class="slds-p-around_small">
+              <lightning-combobox
+                label="Record"
+                value={recordId}
+                options={recordOptions}
+                onchange={handleRecordChange}
+              >
+              </lightning-combobox>
+
+              <div class="slds-m-top_small">
+                <lightning-formatted-text value={recordId}>
+                </lightning-formatted-text>
+              </div>
+            </div>
+          </lightning-card>
+
+          <!-- Book / Sheet -->
+          <lightning-card title="Book / Sheet" class="slds-m-top_medium">
+            <div class="slds-p-around_small">
+              <lightning-combobox
+                label="Book"
+                value={bookId}
+                options={bookOptions}
+                onchange={handleBookChange}
+              >
+              </lightning-combobox>
+
+              <lightning-combobox
+                class="slds-m-top_small"
+                label="Sheet"
+                value={sheetId}
+                options={sheetOptions}
+                onchange={handleSheetChange}
+              >
+              </lightning-combobox>
+            </div>
+          </lightning-card>
+
+          <!-- Runtime Parameters -->
+          <lightning-card title="Runtime Parameters" class="slds-m-top_medium">
+            <div class="slds-p-around_small">
+              <lightning-combobox
+                label="Scenario"
+                value={scenario}
+                options={scenarioOptions}
+                onchange={handleScenarioChange}
+              >
+              </lightning-combobox>
+
+              <lightning-combobox
+                class="slds-m-top_small"
+                label="Region"
+                value={region}
+                options={regionOptions}
+                onchange={handleRegionChange}
+              >
+              </lightning-combobox>
+
+              <lightning-combobox
+                class="slds-m-top_small"
+                label="Theme"
+                value={theme}
+                options={themeOptions}
+                onchange={handleThemeChange}
+              >
+              </lightning-combobox>
+
+              <lightning-input
+                class="slds-m-top_small"
+                type="checkbox"
+                label="Enable Recommendation"
+                checked={enableRecommendation}
+                onchange={handleRecommendationChange}
+              >
+              </lightning-input>
+
+              <lightning-input
+                type="checkbox"
+                label="Enable Advanced Actions"
+                checked={enableAdvancedActions}
+                onchange={handleAdvancedActionsChange}
+              >
+              </lightning-input>
+
+              <lightning-button
+                class="slds-m-top_medium"
+                variant="brand"
+                label="Apply Parameters"
+                onclick={handleApplyParameters}
+              >
+              </lightning-button>
+            </div>
+          </lightning-card>
+        </div>
+
+        <!-- Right Panel -->
+        <div class="slds-col slds-size_3-of-4">
+          <!-- Sheet -->
+          <lightning-card title="Sheet">
+            <div class="sheet-container">
+              <msmxsheet-sheet-component
+                title="Custom Code Example"
+                book-id={bookId}
+                sheet-id={sheetId}
+                record-id={recordId}
+                height="560px"
+                publish-events
+                component-id={componentId}
+                parameters={initialParameters}
+                onselectrecord={handleSelectRecord}
+              >
+              </msmxsheet-sheet-component>
+            </div>
+          </lightning-card>
+
+          <!-- Event Log -->
+          <lightning-card title="Event Log" class="slds-m-top_medium">
+            <div class="event-log">
+              <template if:true={eventLogs.length}>
+                <template for:each={eventLogs} for:item="eventLog">
+                  <div key={eventLog.id} class="slds-p-vertical_x-small">
+                    {eventLog.message}
+                  </div>
+                </template>
+              </template>
+
+              <template if:false={eventLogs.length}>
+                <div class="slds-text-color_weak">No events yet.</div>
+              </template>
+            </div>
+          </lightning-card>
+        </div>
+      </div>
+    </div>
+  </lightning-card>
+</template>

--- a/force-app/main/default/lwc/sheetIntegrationExample/sheetIntegrationExample.js
+++ b/force-app/main/default/lwc/sheetIntegrationExample/sheetIntegrationExample.js
@@ -1,0 +1,205 @@
+import { LightningElement, track, wire } from "lwc";
+import { MessageContext, publish } from "lightning/messageService";
+
+import SET_PARAMETERS_CHANNEL from "@salesforce/messageChannel/msmxSheet__setParameters__c";
+
+export default class SheetIntegrationExample extends LightningElement {
+  @wire(MessageContext)
+  messageContext;
+
+  componentId = "sheet-integration-example";
+
+  recordId = "500AAAAAAAAAAAA";
+
+  bookId = "book-1";
+
+  sheetId = "sheet-1";
+
+  scenario = "managerReview";
+
+  region = "apac";
+
+  theme = "standard";
+
+  enableRecommendation = true;
+
+  enableAdvancedActions = false;
+
+  nextEventId = 1;
+
+  @track
+  eventLogs = [];
+
+  recordOptions = [
+    {
+      label: "Case A",
+      value: "500AAAAAAAAAAAA"
+    },
+    {
+      label: "Case B",
+      value: "500BBBBBBBBBBBB"
+    },
+    {
+      label: "Case C",
+      value: "500CCCCCCCCCCCC"
+    }
+  ];
+
+  bookOptions = [
+    {
+      label: "Sales",
+      value: "book-1"
+    },
+    {
+      label: "Service",
+      value: "book-2"
+    },
+    {
+      label: "Operations",
+      value: "book-3"
+    }
+  ];
+
+  sheetOptions = [
+    {
+      label: "Overview",
+      value: "sheet-1"
+    },
+    {
+      label: "Detail",
+      value: "sheet-2"
+    },
+    {
+      label: "Analytics",
+      value: "sheet-3"
+    }
+  ];
+
+  scenarioOptions = [
+    {
+      label: "Manager Review",
+      value: "managerReview"
+    },
+    {
+      label: "Agent Support",
+      value: "agentSupport"
+    },
+    {
+      label: "Executive Dashboard",
+      value: "executiveDashboard"
+    }
+  ];
+
+  regionOptions = [
+    {
+      label: "APAC",
+      value: "apac"
+    },
+    {
+      label: "EMEA",
+      value: "emea"
+    },
+    {
+      label: "AMER",
+      value: "amer"
+    }
+  ];
+
+  themeOptions = [
+    {
+      label: "Compact",
+      value: "compact"
+    },
+    {
+      label: "Standard",
+      value: "standard"
+    }
+  ];
+
+  get initialParameters() {
+    return [
+      `scenario=${encodeURIComponent(this.scenario)}`,
+      `region=${encodeURIComponent(this.region)}`,
+      `theme=${encodeURIComponent(this.theme)}`,
+      `enableRecommendation=${this.enableRecommendation}`,
+      `enableAdvancedActions=${this.enableAdvancedActions}`
+    ].join("&");
+  }
+
+  handleRecordChange(event) {
+    this.recordId = event.detail.value;
+
+    this.addEventLog(`Context changed: ${this.recordId}`);
+  }
+
+  handleBookChange(event) {
+    this.bookId = event.detail.value;
+
+    this.addEventLog(`Book changed: ${this.bookId}`);
+  }
+
+  handleSheetChange(event) {
+    this.sheetId = event.detail.value;
+
+    this.addEventLog(`Sheet changed: ${this.sheetId}`);
+  }
+
+  handleScenarioChange(event) {
+    this.scenario = event.detail.value;
+  }
+
+  handleRegionChange(event) {
+    this.region = event.detail.value;
+  }
+
+  handleThemeChange(event) {
+    this.theme = event.detail.value;
+  }
+
+  handleRecommendationChange(event) {
+    this.enableRecommendation = event.target.checked;
+  }
+
+  handleAdvancedActionsChange(event) {
+    this.enableAdvancedActions = event.target.checked;
+  }
+
+  handleApplyParameters() {
+    publish(this.messageContext, SET_PARAMETERS_CHANNEL, {
+      componentId: this.componentId,
+      parameters: {
+        scenario: this.scenario,
+        region: this.region,
+        theme: this.theme,
+        enableRecommendation: this.enableRecommendation,
+        enableAdvancedActions: this.enableAdvancedActions
+      },
+      partial: true,
+      forceLoad: true
+    });
+
+    this.addEventLog("Runtime parameters updated");
+  }
+
+  handleSelectRecord(event) {
+    const { recordId, recordIds } = event.detail;
+
+    this.addEventLog(`Record selected: ${recordId}`);
+
+    if (recordIds) {
+      this.addEventLog(`Selected records: ${recordIds}`);
+    }
+  }
+
+  addEventLog(message) {
+    const timestamp = new Date().toLocaleTimeString();
+
+    this.eventLogs = [
+      {
+        id: this.nextEventId++,
+        message: `[${timestamp}] ${message}`
+      },
+      ...this.eventLogs
+    ];
+  }
+}

--- a/force-app/main/default/lwc/sheetIntegrationExample/sheetIntegrationExample.js-meta.xml
+++ b/force-app/main/default/lwc/sheetIntegrationExample/sheetIntegrationExample.js-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>57.0</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__AppPage</target>
+        <target>lightning__HomePage</target>
+        <target>lightning__RecordPage</target>
+    </targets>
+</LightningComponentBundle>

--- a/force-app/main/default/lwc/sheetPlayground/sheetPlayground.css
+++ b/force-app/main/default/lwc/sheetPlayground/sheetPlayground.css
@@ -1,0 +1,340 @@
+:host {
+  display: block;
+}
+
+.main-layout {
+  display: flex;
+  align-items: flex-start;
+  min-height: calc(100vh - 120px);
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.05);
+  overflow: hidden;
+}
+
+.left-panel {
+  flex: 0 0 460px;
+  width: 460px;
+  min-width: 400px;
+  max-width: 580px;
+  padding: 12px 0 12px 12px;
+  background: transparent;
+  overflow: auto;
+}
+
+.left-panel-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.left-panel-card {
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  overflow: hidden;
+  background: #fff;
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.04);
+}
+
+.sample-hero {
+  padding: 20px 20px 16px;
+  border-bottom: 1px solid #e0e0e0;
+  background: linear-gradient(180deg, #f8fbff 0%, #ffffff 100%);
+}
+
+.sample-hero-kicker {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #0b5cff;
+  margin-bottom: 8px;
+}
+
+.sample-hero-title {
+  font-size: 20px;
+  font-weight: 700;
+  color: #13294b;
+}
+
+.sample-hero-description {
+  margin-top: 8px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: #5f6b7a;
+}
+
+.right-panel {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px;
+  background: transparent;
+}
+
+.panel-section {
+  padding: 16px;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.panel-section:last-child {
+  border-bottom: none;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.section-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  font-weight: 700;
+  color: #0b5cff;
+  text-transform: uppercase;
+}
+
+.section-icon {
+  font-size: 12px;
+}
+
+.component-config {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.config-grid {
+  display: grid;
+  gap: 12px;
+}
+
+.config-grid-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.compact-field {
+  --sds-c-input-sizing-min-height: 2rem;
+  --sds-c-combobox-sizing-min-height: 2rem;
+}
+
+.checkbox-field {
+  display: flex;
+  align-items: center;
+  min-height: 2rem;
+  padding-top: 1.4rem;
+}
+
+.record-summary {
+  margin-top: 8px;
+  padding: 12px;
+  border-radius: 4px;
+  background: #f4f6f9;
+}
+
+.record-summary-label {
+  font-size: 11px;
+  color: #666;
+}
+
+.record-summary-value {
+  margin-top: 4px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #0b5cff;
+  word-break: break-all;
+}
+
+.summary-record-ids {
+  max-height: 100px;
+  overflow: auto;
+}
+
+.record-action-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.settings-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding-top: 12px;
+  border-top: 1px solid #e0e0e0;
+}
+
+.apply-button {
+  min-width: 150px;
+}
+
+.settings-note {
+  font-size: 11px;
+  color: #6b7280;
+  line-height: 1.4;
+}
+
+.sheet-panel,
+.event-log-panel {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  overflow: hidden;
+  background: #fff;
+}
+
+.sheet-content {
+  padding: 12px;
+}
+
+.sheet-container {
+  width: 100%;
+}
+
+.sheet-component-header {
+  display: flex;
+  align-items: center;
+  padding: 12px 16px;
+  border-bottom: 1px solid #e0e0e0;
+  background: #f8f9fa;
+}
+
+.sheet-component-title {
+  font-size: 12px;
+  font-weight: 700;
+  color: #000;
+  text-transform: uppercase;
+}
+
+.sheet-component {
+  display: block;
+  width: 100%;
+}
+
+.event-log-panel {
+  min-height: 0;
+}
+
+.event-log-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 16px;
+  border-bottom: 1px solid #e0e0e0;
+  background: #f8f9fa;
+}
+
+.event-log-title {
+  font-size: 12px;
+  font-weight: 700;
+  color: #000;
+  text-transform: uppercase;
+}
+
+.event-log-body {
+  max-height: 320px;
+  overflow: auto;
+}
+
+.event-log-detail {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.event-log-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 11px;
+}
+
+.event-log-table th,
+.event-log-table td {
+  padding: 8px 12px;
+  text-align: left;
+  border-right: 1px solid #e0e0e0;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.event-log-table th:last-child,
+.event-log-table td:last-child {
+  border-right: none;
+}
+
+.event-log-table th {
+  background: #f8f9fa;
+  font-weight: 700;
+  color: #333;
+}
+
+.event-level {
+  display: inline-block;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 10px;
+  font-weight: 600;
+}
+
+.event-log-info {
+  background: #e0f2fe;
+  color: #0284c7;
+}
+
+.event-log-error {
+  background: #fee2e2;
+  color: #dc2626;
+}
+
+.empty-state {
+  padding: 12px 16px;
+  color: #666;
+  font-size: 12px;
+}
+
+@media screen and (max-width: 1024px) {
+  .main-layout {
+    flex-direction: column;
+  }
+
+  .left-panel {
+    width: 100%;
+    flex-basis: auto;
+    max-width: none;
+    padding: 12px 12px 0;
+  }
+
+  .right-panel {
+    padding: 12px 0 0;
+  }
+
+  .config-grid-2 {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-footer {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .apply-button {
+    width: 100%;
+    text-align: right;
+  }
+
+  .sheet-panel,
+  .event-log-panel {
+    margin: 0 12px 12px;
+  }
+
+  .event-log-body {
+    max-height: 280px;
+  }
+}

--- a/force-app/main/default/lwc/sheetPlayground/sheetPlayground.html
+++ b/force-app/main/default/lwc/sheetPlayground/sheetPlayground.html
@@ -1,0 +1,241 @@
+<template>
+  <div class="main-layout">
+    <div class="left-panel">
+      <div class="left-panel-stack">
+        <div class="left-panel-card">
+          <div class="sample-hero">
+            <div class="sample-hero-kicker">Sheet Integration</div>
+            <div class="sample-hero-title">Sheet Component Playground</div>
+            <div class="sample-hero-description">
+              Experiment with different books, sheets, parameters, and record
+              contexts in a self-contained LWC example.
+            </div>
+          </div>
+
+          <section class="panel-section">
+            <div class="section-header">
+              <div class="section-title">
+                <span class="section-icon">1</span>
+                Book &amp; Sheet
+              </div>
+              <lightning-helptext
+                content="Select a book and the sheet you want to display."
+              ></lightning-helptext>
+            </div>
+
+            <lightning-combobox
+              class="compact-field slds-m-bottom_small"
+              label="Book"
+              value={draft.bookId}
+              options={bookOptions}
+              onchange={handleBookChange}
+            ></lightning-combobox>
+
+            <lightning-combobox
+              class="compact-field"
+              label="Sheet"
+              value={draft.sheetId}
+              options={sheetOptions}
+              onchange={handleSheetChange}
+              disabled={sheetDisabled}
+            ></lightning-combobox>
+          </section>
+
+          <section class="panel-section">
+            <div class="section-header section-header-row">
+              <div class="section-title">
+                <span class="section-icon">2</span>
+                Component Settings
+              </div>
+              <lightning-helptext
+                content="Update the draft configuration. Changes are applied only after you click Apply Settings."
+              ></lightning-helptext>
+            </div>
+
+            <div class="component-config">
+              <div class="config-grid config-grid-2">
+                <lightning-input
+                  class="compact-field"
+                  label="Component ID"
+                  value={draft.componentId}
+                  onchange={handleComponentIdChange}
+                ></lightning-input>
+
+                <lightning-input
+                  class="compact-field"
+                  label="Title"
+                  value={draft.title}
+                  onchange={handleComponentTitleChange}
+                ></lightning-input>
+              </div>
+
+              <div class="config-grid config-grid-2">
+                <lightning-input
+                  class="compact-field"
+                  type="text"
+                  label="Height"
+                  value={draft.height}
+                  onchange={handleComponentHeightChange}
+                  placeholder="500px or 80vh"
+                ></lightning-input>
+
+                <div class="checkbox-field">
+                  <lightning-input
+                    type="checkbox"
+                    label="Publish Events"
+                    checked={draft.publishEvents}
+                    onchange={handlePublishEventsChange}
+                  ></lightning-input>
+                </div>
+              </div>
+
+              <lightning-input
+                class="compact-field"
+                type="text"
+                label="Parameters"
+                value={draft.parameters}
+                onchange={handleParametersChange}
+                placeholder="e.g. param1=value1&amp;param2=value2"
+              ></lightning-input>
+
+              <div class="settings-footer">
+                <div class="settings-note">
+                  Changes won't affect the sheet until you click Apply Settings.
+                </div>
+                <lightning-button
+                  variant="brand"
+                  label="Apply Settings"
+                  onclick={handleApplySettings}
+                  class="apply-button"
+                ></lightning-button>
+              </div>
+            </div>
+          </section>
+
+          <section class="panel-section">
+            <div class="section-header">
+              <div class="section-title">
+                <span class="section-icon">3</span>
+                Record Context
+              </div>
+              <lightning-helptext
+                content="Choose which record should be used as the sheet context."
+              ></lightning-helptext>
+            </div>
+
+            <lightning-input
+              class="compact-field"
+              label="Context Record ID"
+              value={draft.contextRecordId}
+              onchange={handleContextRecordIdChange}
+            ></lightning-input>
+
+            <div
+              class="record-action-row slds-m-top_x-small slds-m-bottom_small"
+            >
+              <lightning-button
+                variant="neutral"
+                label="Use Selected Record"
+                onclick={handleUseSelectedRecord}
+                disabled={selectedRecordActionDisabled}
+              ></lightning-button>
+              <lightning-button
+                variant="neutral"
+                label="Reset to Page Record"
+                onclick={handleResetContextRecord}
+              ></lightning-button>
+            </div>
+
+            <div class="record-summary">
+              <div class="record-summary-label">Page Record ID</div>
+              <div class="record-summary-value">{pageRecordIdDisplay}</div>
+            </div>
+
+            <div class="record-summary">
+              <div class="record-summary-label">Selected Record ID</div>
+              <div class="record-summary-value">{selectedRecordIdDisplay}</div>
+            </div>
+
+            <div class="record-summary">
+              <div class="record-summary-label">Selected Record IDs</div>
+              <div class="record-summary-value summary-record-ids">
+                {selectedRecordIdsDisplay}
+              </div>
+            </div>
+
+            <div class="section-help section-help-compact">
+              The first selected record from the sheet will be used when you
+              click Use Selected Record.
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+
+    <div class="right-panel">
+      <div class="sheet-panel">
+        <div class="sample-hero">
+          <div class="sample-hero-title">Sheet Preview</div>
+        </div>
+        <div class="sheet-content">
+          <div class="sheet-container">
+            <msmxsheet-sheet-component
+              class="sheet-component"
+              title={applied.title}
+              book-id={applied.bookId}
+              sheet-id={applied.sheetId}
+              record-id={applied.contextRecordId}
+              parameters={applied.parameters}
+              publish-events={applied.publishEvents}
+              component-id={applied.componentId}
+              height={applied.height}
+              onselectrecord={handleSelectRecord}
+            ></msmxsheet-sheet-component>
+          </div>
+        </div>
+      </div>
+      <div class="event-log-panel">
+        <div class="event-log-header">
+          <div class="event-log-title">Event Log</div>
+          <lightning-button
+            variant="neutral"
+            label="Clear Log"
+            icon-name="utility:delete"
+            onclick={handleClearLog}
+          ></lightning-button>
+        </div>
+
+        <div class="event-log-body">
+          <template if:true={eventLogs.length}>
+            <table class="event-log-table">
+              <thead>
+                <tr>
+                  <th>Time</th>
+                  <th>Level</th>
+                  <th>Message</th>
+                  <th>Detail</th>
+                </tr>
+              </thead>
+              <tbody>
+                <template for:each={eventLogs} for:item="eventLog">
+                  <tr key={eventLog.id} class="event-log-row">
+                    <td>{eventLog.time}</td>
+                    <td>
+                      <span class={eventLog.eventClass}>{eventLog.level}</span>
+                    </td>
+                    <td>{eventLog.message}</td>
+                    <td class="event-log-detail">{eventLog.detail}</td>
+                  </tr>
+                </template>
+              </tbody>
+            </table>
+          </template>
+
+          <template if:false={eventLogs.length}>
+            <div class="empty-state">No events recorded.</div>
+          </template>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/force-app/main/default/lwc/sheetPlayground/sheetPlayground.js
+++ b/force-app/main/default/lwc/sheetPlayground/sheetPlayground.js
@@ -1,0 +1,291 @@
+import { LightningElement, api, wire } from "lwc";
+import getBooks from "@salesforce/apex/SheetPlaygroundController.getBooks";
+import getSheets from "@salesforce/apex/SheetPlaygroundController.getSheets";
+
+const DEFAULT_COMPONENT_ID = "sheet-integration-example";
+const DEFAULT_COMPONENT_TITLE = "Custom Code Example";
+const DEFAULT_COMPONENT_HEIGHT = "500px";
+
+export default class SheetPlayground extends LightningElement {
+  _recordId;
+
+  bookOptions = [];
+  sheetOptions = [];
+  eventLogs = [];
+
+  draft = {
+    bookId: "",
+    sheetId: "",
+    componentId: DEFAULT_COMPONENT_ID,
+    title: DEFAULT_COMPONENT_TITLE,
+    height: DEFAULT_COMPONENT_HEIGHT,
+    publishEvents: true,
+    parameters: "",
+    contextRecordId: ""
+  };
+
+  applied = {
+    bookId: "",
+    sheetId: "",
+    componentId: DEFAULT_COMPONENT_ID,
+    title: DEFAULT_COMPONENT_TITLE,
+    height: DEFAULT_COMPONENT_HEIGHT,
+    publishEvents: true,
+    parameters: "",
+    contextRecordId: ""
+  };
+
+  sheetDisabled = true;
+  selectedRecordId = "";
+  selectedRecordIds = "";
+  nextEventId = 1;
+  logLevels = {
+    INFO: "Info",
+    ERROR: "Error"
+  };
+
+  @api
+  get recordId() {
+    return this._recordId;
+  }
+
+  set recordId(value) {
+    this._recordId = value;
+
+    if (!this.draft.contextRecordId && !this.applied.contextRecordId && value) {
+      this.draft.contextRecordId = value;
+      this.applied.contextRecordId = value;
+    }
+  }
+
+  get selectedRecordActionDisabled() {
+    return !this.selectedRecordId;
+  }
+
+  get pageRecordIdDisplay() {
+    return this.recordId || "-";
+  }
+
+  get selectedRecordIdDisplay() {
+    return this.selectedRecordId || "-";
+  }
+
+  get selectedRecordIdsDisplay() {
+    return this.selectedRecordIds || "-";
+  }
+
+  @wire(getBooks)
+  wiredBooks({ error, data }) {
+    if (data) {
+      this.bookOptions = data.map((book) => ({
+        label: book.Name,
+        value: book.Id
+      }));
+
+      const selectedBookId =
+        this.bookOptions.find((option) => option.value === this.draft.bookId)
+          ?.value ||
+        this.bookOptions[0]?.value ||
+        "";
+
+      if (selectedBookId) {
+        this.draft.bookId = selectedBookId;
+
+        if (!this.applied.bookId) {
+          this.applied.bookId = selectedBookId;
+        }
+
+        this.loadSheets(selectedBookId);
+      }
+    } else if (error) {
+      this.bookOptions = [];
+      this.addEventLog(
+        "Unable to load books from msmxSheet__msmxBook__c",
+        this.logLevels.ERROR,
+        {
+          message: error.body?.message || error.message
+        }
+      );
+    }
+  }
+
+  loadSheets(bookId) {
+    getSheets({ bookId })
+      .then((data) => {
+        this.sheetOptions = data.map((sheet) => ({
+          label: sheet.Name,
+          value: sheet.msmxSheet__SheetId__c
+        }));
+
+        if (
+          !this.sheetOptions.some(
+            (option) => option.value === this.draft.sheetId
+          )
+        ) {
+          this.draft.sheetId = "";
+        }
+
+        this.sheetDisabled = this.sheetOptions.length === 0;
+      })
+      .catch((error) => {
+        this.sheetOptions = [];
+        this.draft.sheetId = "";
+        this.sheetDisabled = true;
+        this.addEventLog(
+          `Unable to load sheets for book ${bookId}`,
+          this.logLevels.ERROR,
+          {
+            bookId,
+            message: error.body?.message || error.message
+          }
+        );
+      });
+  }
+
+  handleBookChange(event) {
+    this.draft.bookId = event.detail.value;
+    this.draft.sheetId = "";
+    this.sheetOptions = [];
+    this.sheetDisabled = true;
+
+    if (this.draft.bookId) {
+      this.loadSheets(this.draft.bookId);
+    }
+
+    this.addEventLog("Book draft changed", this.logLevels.INFO, {
+      bookId: this.draft.bookId
+    });
+  }
+
+  handleSheetChange(event) {
+    this.draft.sheetId = event.detail.value;
+    this.addEventLog("Sheet draft changed", this.logLevels.INFO, {
+      sheetId: this.draft.sheetId
+    });
+  }
+
+  handleComponentIdChange(event) {
+    this.draft.componentId = event.detail.value;
+    this.addEventLog("Component ID draft changed", this.logLevels.INFO, {
+      componentId: this.draft.componentId
+    });
+  }
+
+  handleComponentTitleChange(event) {
+    this.draft.title = event.detail.value;
+    this.addEventLog("Component title draft changed", this.logLevels.INFO, {
+      componentTitle: this.draft.title
+    });
+  }
+
+  handleComponentHeightChange(event) {
+    this.draft.height = event.detail.value || DEFAULT_COMPONENT_HEIGHT;
+    this.addEventLog("Component height draft changed", this.logLevels.INFO, {
+      componentHeight: this.draft.height
+    });
+  }
+
+  handlePublishEventsChange(event) {
+    this.draft.publishEvents = event.target.checked;
+    this.addEventLog("Publish events draft changed", this.logLevels.INFO, {
+      publishEvents: this.draft.publishEvents
+    });
+  }
+
+  handleParametersChange(event) {
+    this.draft.parameters = event.detail.value;
+    this.addEventLog("Parameters draft changed", this.logLevels.INFO, {
+      parameters: this.draft.parameters
+    });
+  }
+
+  handleContextRecordIdChange(event) {
+    this.draft.contextRecordId = event.detail.value;
+    this.applied.contextRecordId = this.draft.contextRecordId;
+    this.addEventLog("Context record changed", this.logLevels.INFO, {
+      contextRecordId: this.applied.contextRecordId
+    });
+  }
+
+  handleUseSelectedRecord() {
+    if (!this.selectedRecordId) {
+      return;
+    }
+    this.draft.contextRecordId = this.selectedRecordId;
+    this.applied.contextRecordId = this.draft.contextRecordId;
+    this.addEventLog(
+      "Context record set from selected record",
+      this.logLevels.INFO,
+      {
+        contextRecordId: this.applied.contextRecordId,
+        source: "selectedRecord"
+      }
+    );
+  }
+
+  handleResetContextRecord() {
+    this.draft.contextRecordId = this.recordId || "";
+    this.applied.contextRecordId = this.draft.contextRecordId;
+    this.addEventLog("Context record reset", this.logLevels.INFO, {
+      contextRecordId: this.applied.contextRecordId,
+      source: "pageRecord"
+    });
+  }
+
+  handleApplySettings() {
+    this.applied = { ...this.draft };
+    this.applied.contextRecordId =
+      this.draft.contextRecordId || this.recordId || "";
+
+    this.addEventLog("Settings applied", this.logLevels.INFO, {
+      ...this.applied
+    });
+  }
+
+  handleClearLog() {
+    this.eventLogs = [];
+  }
+
+  handleSelectRecord(event) {
+    const { recordId, recordIds } = event.detail;
+    this.selectedRecordId = recordId || "";
+    this.selectedRecordIds = Array.isArray(recordIds)
+      ? recordIds.join(", ")
+      : recordIds || "";
+    this.addEventLog("Record selected", this.logLevels.INFO, event.detail);
+  }
+
+  addEventLog(message, level = this.logLevels.INFO, detail = "") {
+    const timestamp = new Date().toLocaleTimeString();
+    this.eventLogs = [
+      {
+        id: this.nextEventId++,
+        time: timestamp,
+        level,
+        eventClass:
+          level === this.logLevels.ERROR
+            ? "event-level event-log-error"
+            : "event-level event-log-info",
+        message,
+        detail: this.formatEventDetail(detail)
+      },
+      ...this.eventLogs
+    ];
+  }
+
+  formatEventDetail(detail) {
+    if (detail === null || detail === undefined || detail === "") {
+      return "";
+    }
+
+    if (typeof detail === "string") {
+      return detail;
+    }
+
+    try {
+      return JSON.stringify(detail, null, 2);
+    } catch (error) {
+      return String(detail);
+    }
+  }
+}

--- a/force-app/main/default/lwc/sheetPlayground/sheetPlayground.js-meta.xml
+++ b/force-app/main/default/lwc/sheetPlayground/sheetPlayground.js-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__AppPage</target>
+        <target>lightning__HomePage</target>
+        <target>lightning__RecordPage</target>
+    </targets>
+</LightningComponentBundle>

--- a/force-app/main/default/permissionsets/Mashmatrix_Sheet_Integration_Examples.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Mashmatrix_Sheet_Integration_Examples.permissionset-meta.xml
@@ -80,4 +80,8 @@
         <tab>Message_Debug</tab>
         <visibility>Visible</visibility>
     </tabSettings>
+    <tabSettings>
+        <tab>Sheet_Playground</tab>
+        <visibility>Visible</visibility>
+    </tabSettings>
 </PermissionSet>

--- a/force-app/main/default/tabs/Sheet_Playground.tab-meta.xml
+++ b/force-app/main/default/tabs/Sheet_Playground.tab-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>Created by Lightning App Builder</description>
+    <flexiPage>Sheet_Playground</flexiPage>
+    <label>Sheet Playground</label>
+    <motif>Custom32: Factory</motif>
+</CustomTab>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -26,7 +26,7 @@
   "name": "msmx-sheet-integration-examples",
   "namespace": "",
   "sfdcLoginUrl": "https://login.salesforce.com",
-  "sourceApiVersion": "57.0",
+  "sourceApiVersion": "66.0",
   "packageAliases": {
     "msmx-sheet-integration-examples": "0HoA70000000006KAA",
     "Mashmatrix Sheet": "04t0K000001E4ll",


### PR DESCRIPTION
### What I Did:

* Added a new **Sheet Playground** LWC sample demonstrating how to embed and interact with the `<msmx-sheet-sheet>` component directly from a custom Lightning Web Component.
* Added a new **Sheet Playground** tab to the **Sheet Integration Example** app.
* Updated the sample permission set to grant access to the new Sheet Playground tab.
* Updated both **README** and **README_ja** with:

  * Usage instructions for the Sheet Playground sample.
  * Technical highlights covering component embedding, property binding, event handling, and manual application patterns.
  * Screenshots illustrating the Sheet Playground UI and behavior.

### Note:

* The sample is currently using an older package version. Due to a known limitation, changes to the `book-id` and `sheet-id` properties are not reflected when these values are updated dynamically after the component has been initialized.
* Once a package version that includes support for dynamic `book-id` / `sheet-id` updates becomes available, the sample and documentation should be revisited and updated accordingly.
